### PR TITLE
Generate Reminder Objects and save during Transmog

### DIFF
--- a/backend_services/lib/agent.dart
+++ b/backend_services/lib/agent.dart
@@ -300,16 +300,16 @@ class Agent {
     conversationsProvider.updateGptReminders(recordingGuid, completion);
     // Create Reminder objects based on completion
     // send to chatgpt
-    final jsonResult = await gpt.convertRemindersToJson(completion, recordingGuid, recordedDate);
+    final jsonResult = await gpt.convertRemindersToJson(
+        completion, recordingGuid, recordedDate);
     var jsonResponse = jsonDecode(jsonResult);
-      var jsonAsList = jsonResponse as List;
-      List<Reminder> reminders = jsonAsList
-          .map<Reminder>((json) => Reminder.fromJson(json))
-          .toList();
-    
-      for (Reminder rem in reminders) {
+    var jsonAsList = jsonResponse as List;
+    List<Reminder> reminders =
+        jsonAsList.map<Reminder>((json) => Reminder.fromJson(json)).toList();
+
+    for (Reminder rem in reminders) {
       conversationsProvider.addReminder(rem);
-      }
+    }
     return completion;
   }
 
@@ -368,16 +368,36 @@ class Agent {
     //Generate sample reminder data from literals
 
     //Sample Data
-    Reminder reminder1 = Reminder('e3bc7acc-3b20-4056-94b6-6199fdba5870', DateTime.now().add(-Duration(hours: 1)),
-        DateTime.now().add(Duration(hours: 1)), 'Description A', 'e3bc7acc-3b20-4056-94b6-6199fdba5870');
-    Reminder reminder2 = Reminder('e3bc7acc-3b20-4056-94b6-6199fdba5871', DateTime.now().add(-Duration(hours: 4)),
-        DateTime.now().add(Duration(hours: 4)), 'Description B', 'e3bc7acc-3b20-4056-94b6-6199fdba5870');
-    Reminder reminder3 = Reminder('e3bc7acc-3b20-4056-94b6-6199fdba5872', DateTime.now().add(-Duration(hours: 34)),
-        DateTime.now().add(Duration(hours: 36)), 'Description C', 'e3bc7acc-3b20-4056-94b6-6199fdba5870');
-    Reminder reminder4 = Reminder('e3bc7acc-3b20-4056-94b6-6199fdba5873', DateTime.now().add(-Duration(hours: 72)),
-        DateTime.now().add(Duration(hours: 72)), 'Description D', 'e3bc7acc-3b20-4056-94b6-6199fdba5870');
-    Reminder reminder5 = Reminder('e3bc7acc-3b20-4056-94b6-6199fdba5874', DateTime.now().add(-Duration(hours: 168)),
-        DateTime.now().add(Duration(hours: 168)), 'Description E', 'e3bc7acc-3b20-4056-94b6-6199fdba5870');
+    Reminder reminder1 = Reminder(
+        'e3bc7acc-3b20-4056-94b6-6199fdba5870',
+        DateTime.now().add(-Duration(hours: 1)),
+        DateTime.now().add(Duration(hours: 1)),
+        'Description A',
+        'e3bc7acc-3b20-4056-94b6-6199fdba5870');
+    Reminder reminder2 = Reminder(
+        'e3bc7acc-3b20-4056-94b6-6199fdba5871',
+        DateTime.now().add(-Duration(hours: 4)),
+        DateTime.now().add(Duration(hours: 4)),
+        'Description B',
+        'e3bc7acc-3b20-4056-94b6-6199fdba5870');
+    Reminder reminder3 = Reminder(
+        'e3bc7acc-3b20-4056-94b6-6199fdba5872',
+        DateTime.now().add(-Duration(hours: 34)),
+        DateTime.now().add(Duration(hours: 36)),
+        'Description C',
+        'e3bc7acc-3b20-4056-94b6-6199fdba5870');
+    Reminder reminder4 = Reminder(
+        'e3bc7acc-3b20-4056-94b6-6199fdba5873',
+        DateTime.now().add(-Duration(hours: 72)),
+        DateTime.now().add(Duration(hours: 72)),
+        'Description D',
+        'e3bc7acc-3b20-4056-94b6-6199fdba5870');
+    Reminder reminder5 = Reminder(
+        'e3bc7acc-3b20-4056-94b6-6199fdba5874',
+        DateTime.now().add(-Duration(hours: 168)),
+        DateTime.now().add(Duration(hours: 168)),
+        'Description E',
+        'e3bc7acc-3b20-4056-94b6-6199fdba5870');
     List<Reminder> sampleReminderList = [
       reminder1,
       reminder2,

--- a/backend_services/lib/agent.dart
+++ b/backend_services/lib/agent.dart
@@ -298,7 +298,18 @@ class Agent {
         recordedDate); //Todo implement user profile argument if desired
     // write Reminder Transmog result to conversation
     conversationsProvider.updateGptReminders(recordingGuid, completion);
-    // todo create Reminder objects based on completion
+    // Create Reminder objects based on completion
+    // send to chatgpt
+    final jsonResult = await gpt.convertRemindersToJson(completion, recordingGuid, recordedDate);
+    var jsonResponse = jsonDecode(jsonResult);
+      var jsonAsList = jsonResponse as List;
+      List<Reminder> reminders = jsonAsList
+          .map<Reminder>((json) => Reminder.fromJson(json))
+          .toList();
+    
+      for (Reminder rem in reminders) {
+      conversationsProvider.addReminder(rem);
+      }
     return completion;
   }
 
@@ -357,16 +368,16 @@ class Agent {
     //Generate sample reminder data from literals
 
     //Sample Data
-    Reminder reminder1 = Reminder(1, DateTime.now().add(-Duration(hours: 1)),
-        DateTime.now().add(Duration(hours: 1)), 'Description A', 'User');
-    Reminder reminder2 = Reminder(2, DateTime.now().add(-Duration(hours: 4)),
-        DateTime.now().add(Duration(hours: 4)), 'Description B', 'User');
-    Reminder reminder3 = Reminder(3, DateTime.now().add(-Duration(hours: 34)),
-        DateTime.now().add(Duration(hours: 36)), 'Description C', 'User');
-    Reminder reminder4 = Reminder(4, DateTime.now().add(-Duration(hours: 72)),
-        DateTime.now().add(Duration(hours: 72)), 'Description D', 'User');
-    Reminder reminder5 = Reminder(5, DateTime.now().add(-Duration(hours: 168)),
-        DateTime.now().add(Duration(hours: 168)), 'Description E', 'User');
+    Reminder reminder1 = Reminder('e3bc7acc-3b20-4056-94b6-6199fdba5870', DateTime.now().add(-Duration(hours: 1)),
+        DateTime.now().add(Duration(hours: 1)), 'Description A', 'e3bc7acc-3b20-4056-94b6-6199fdba5870');
+    Reminder reminder2 = Reminder('e3bc7acc-3b20-4056-94b6-6199fdba5871', DateTime.now().add(-Duration(hours: 4)),
+        DateTime.now().add(Duration(hours: 4)), 'Description B', 'e3bc7acc-3b20-4056-94b6-6199fdba5870');
+    Reminder reminder3 = Reminder('e3bc7acc-3b20-4056-94b6-6199fdba5872', DateTime.now().add(-Duration(hours: 34)),
+        DateTime.now().add(Duration(hours: 36)), 'Description C', 'e3bc7acc-3b20-4056-94b6-6199fdba5870');
+    Reminder reminder4 = Reminder('e3bc7acc-3b20-4056-94b6-6199fdba5873', DateTime.now().add(-Duration(hours: 72)),
+        DateTime.now().add(Duration(hours: 72)), 'Description D', 'e3bc7acc-3b20-4056-94b6-6199fdba5870');
+    Reminder reminder5 = Reminder('e3bc7acc-3b20-4056-94b6-6199fdba5874', DateTime.now().add(-Duration(hours: 168)),
+        DateTime.now().add(Duration(hours: 168)), 'Description E', 'e3bc7acc-3b20-4056-94b6-6199fdba5870');
     List<Reminder> sampleReminderList = [
       reminder1,
       reminder2,
@@ -374,8 +385,10 @@ class Agent {
       reminder4,
       reminder5
     ];
-
     reminderList = sampleReminderList;
+    for (var rem in reminderList) {
+      conversationsProvider.addReminder(rem);
+    }
   }
 
   void writeRemindersToFile() async {

--- a/backend_services/lib/model/reminder.dart
+++ b/backend_services/lib/model/reminder.dart
@@ -1,24 +1,24 @@
 class Reminder {
-  final int reminderId;
+  final String reminderId;
   final DateTime createTimestamp;
   final DateTime notifyTimestamp;
   late String reminderDescription;
-  late String userId;
+  late String guid;
 
-  Reminder(this.reminderId, this.createTimestamp, this.notifyTimestamp, this.reminderDescription, this.userId);
+  Reminder(this.reminderId, this.createTimestamp, this.notifyTimestamp, this.reminderDescription, this.guid);
 
   Reminder.fromJson(Map<String, dynamic> json)
-      : reminderId = json['reminderId'] as int,
+      : reminderId = json['reminderId'] as String,
         createTimestamp = DateTime.parse(json['createTimestamp']),
         notifyTimestamp = DateTime.parse(json['notifyTimestamp']),
         reminderDescription = json['reminderDescription'] as String,
-        userId = json['userId'] as String;
+        guid = json['guid'] ?? '';
 
   Map<String, dynamic> toJson() => {
         'reminderId': reminderId,
         'createTimestamp': createTimestamp.toIso8601String(),
         'notifyTimestamp': notifyTimestamp.toIso8601String(),
         'reminderDescription': reminderDescription,
-        'userId': userId,
+        'userId': guid,
       };
 }

--- a/backend_services/lib/model/reminder.dart
+++ b/backend_services/lib/model/reminder.dart
@@ -3,15 +3,18 @@ class Reminder {
   final DateTime createTimestamp;
   final DateTime notifyTimestamp;
   late String reminderDescription;
+  // JN: SM: recordingId?
   late String guid;
 
-  Reminder(this.reminderId, this.createTimestamp, this.notifyTimestamp, this.reminderDescription, this.guid);
+  Reminder(this.reminderId, this.createTimestamp, this.notifyTimestamp,
+      this.reminderDescription, this.guid);
 
   Reminder.fromJson(Map<String, dynamic> json)
       : reminderId = json['reminderId'] as String,
         createTimestamp = DateTime.parse(json['createTimestamp']),
         notifyTimestamp = DateTime.parse(json['notifyTimestamp']),
         reminderDescription = json['reminderDescription'] as String,
+        // JN: SM: This needs to be the same as property name in toJson()
         guid = json['guid'] ?? '';
 
   Map<String, dynamic> toJson() => {
@@ -19,6 +22,7 @@ class Reminder {
         'createTimestamp': createTimestamp.toIso8601String(),
         'notifyTimestamp': notifyTimestamp.toIso8601String(),
         'reminderDescription': reminderDescription,
+        // JN: SM: looks like this should be recordingId
         'userId': guid,
       };
 }

--- a/backend_services/lib/model/reminder.dart
+++ b/backend_services/lib/model/reminder.dart
@@ -3,26 +3,23 @@ class Reminder {
   final DateTime createTimestamp;
   final DateTime notifyTimestamp;
   late String reminderDescription;
-  // JN: SM: recordingId?
-  late String guid;
+  late String recordingId;
 
   Reminder(this.reminderId, this.createTimestamp, this.notifyTimestamp,
-      this.reminderDescription, this.guid);
+      this.reminderDescription, this.recordingId);
 
   Reminder.fromJson(Map<String, dynamic> json)
       : reminderId = json['reminderId'] as String,
         createTimestamp = DateTime.parse(json['createTimestamp']),
         notifyTimestamp = DateTime.parse(json['notifyTimestamp']),
         reminderDescription = json['reminderDescription'] as String,
-        // JN: SM: This needs to be the same as property name in toJson()
-        guid = json['guid'] ?? '';
+        recordingId = json['recordingId'] ?? '';
 
   Map<String, dynamic> toJson() => {
         'reminderId': reminderId,
         'createTimestamp': createTimestamp.toIso8601String(),
         'notifyTimestamp': notifyTimestamp.toIso8601String(),
         'reminderDescription': reminderDescription,
-        // JN: SM: looks like this should be recordingId
-        'userId': guid,
+        'recordingId': recordingId,
       };
 }

--- a/backend_services/lib/src/gpt-service/GptCalls.dart
+++ b/backend_services/lib/src/gpt-service/GptCalls.dart
@@ -1,6 +1,5 @@
 import 'package:dart_openai/dart_openai.dart';
 import 'package:logger/logger.dart';
-import 'package:uuid/uuid.dart';
 
 class GptCalls {
   GptCalls(this._openAIApiKey);

--- a/backend_services/lib/src/gpt-service/GptCalls.dart
+++ b/backend_services/lib/src/gpt-service/GptCalls.dart
@@ -144,7 +144,7 @@ Please ensure that every field in the list of fields has a value filled in, and 
 
     // JN: SM: Why is the 5th property id here and and guid in the object and userId in the file?  Seems like it should be recordingId.
     final convertRemindersToJsonPrompt =
-        '''You are a reminders assistant.  Convert the following list of reminder source data into JSON format, using fields "reminderId" "createTimestamp" "notifyTimestamp" "reminderDescription" "id".  There may be multiple reminders in the source data.  Create JSON for all reminders.
+        '''You are a reminders assistant.  Convert the following list of reminder source data into JSON format, using fields "reminderId" "createTimestamp" "notifyTimestamp" "reminderDescription" "id".  There may be multiple reminders in the source data.  Create JSON for all reminders.  The response must only consist of complete properly-formatted JSON.
 
 Attributes common to each reminder: 
 

--- a/backend_services/lib/src/gpt-service/GptCalls.dart
+++ b/backend_services/lib/src/gpt-service/GptCalls.dart
@@ -10,7 +10,8 @@ class GptCalls {
 
   //String browserRequest;
   //String userProfile;
-  final String restaurantPrompt = '''You are a restaurant assistant.  Take the following audio transcript of a waiter taking patrons' orders and generate a summary of patrons' orders at a restaurant.  There may be up to 10 speakers in the conversation.  Different speakers' voices are indicated by "spk_0", "spk_1", "spk_2" or up to "spk_9".  You must separate out different speakers' orders and refer to them using using "Seat 1", "Seat 2", "Seat 3", etc.
+  final String restaurantPrompt =
+      '''You are a restaurant assistant.  Take the following audio transcript of a waiter taking patrons' orders and generate a summary of patrons' orders at a restaurant.  There may be up to 10 speakers in the conversation.  Different speakers' voices are indicated by "spk_0", "spk_1", "spk_2" or up to "spk_9".  You must separate out different speakers' orders and refer to them using using "Seat 1", "Seat 2", "Seat 3", etc.
 
 Example format:
 
@@ -35,7 +36,8 @@ Speaker1: Did you get Mike's invitation to the party?
 
 Speaker2: Yes, I'm looking forward to it.''';
 
-  final reminderPrompt = '''You are a reminder assistant.  Take the following audio transcript and generate a list of reminders for a person with short term memory loss.  Provide clear reminder descriptions and date/times for reminders that will occur within the next 7 days.
+  final reminderPrompt =
+      '''You are a reminder assistant.  Take the following audio transcript and generate a list of reminders for a person with short term memory loss.  Provide clear reminder descriptions and date/times for reminders that will occur within the next 7 days.
 
 Provide a description date/time of the following format:
 
@@ -45,9 +47,6 @@ Reminder 2: 2023-08-04T11:00, Call Michael
 If this is a conversation about food orders in a restaurant, apologize that you are unable to generate reminders.
 
 ''';
-
-
-
 
   Future<String?> getOpenAiSummary(
     String transcript,
@@ -66,7 +65,7 @@ If this is a conversation about food orders in a restaurant, apologize that you 
     final completion = await OpenAI.instance.chat
         .create(model: "gpt-3.5-turbo", messages: messages);
 
-    return completion.choices[0].message.content; 
+    return completion.choices[0].message.content;
     //The conversation involves Speaker 1 expressing their hesitation and uncertainty about their pain tolerance, while Speaker 2 reassures them and expresses readiness to start the activity.
     // Possible Error: RequestFailedException (RequestFailedException{message: That model is currently overloaded with other requests. You can retry your request, or contact us through our help center at help.openai.com if the error persists. (Please include the request ID d946214a3b7fa731346976ac8a39e724 in your message.), statusCode: 503})
   }
@@ -119,11 +118,12 @@ Please ensure that every field in the list of fields has a value filled in, and 
     return completion.choices[0].message.content;
   }
 
-    Future<String> getReminders(
+  Future<String> getReminders(
       String transcript, String userProfile, DateTime recordedDate) async {
     OpenAI.apiKey = _openAIApiKey;
 
-    String reminderPromptToSend = '$reminderPrompt \n The Current Date and time is: ${recordedDate.toIso8601String()}\n The Audio Transcript:\n$transcript';
+    String reminderPromptToSend =
+        '$reminderPrompt \n The Current Date and time is: ${recordedDate.toIso8601String()}\n The Audio Transcript:\n$transcript';
 
     _logger.i(reminderPromptToSend);
 
@@ -139,10 +139,12 @@ Please ensure that every field in the list of fields has a value filled in, and 
   }
 
   Future<String> convertRemindersToJson(
-    String reminderText, String guid, DateTime createTimestamp) async {
-      OpenAI.apiKey = _openAIApiKey;
-        final convertRemindersToJsonPrompt = 
-  '''You are a reminders assistant.  Convert the following list of reminder source data into JSON format, using fields "reminderId" "createTimestamp" "notifyTimestamp" "reminderDescription" "id".  There may be multiple reminders in the source data.  Create JSON for all reminders.
+      String reminderText, String guid, DateTime createTimestamp) async {
+    OpenAI.apiKey = _openAIApiKey;
+
+    // JN: SM: Why is the 5th property id here and and guid in the object and userId in the file?  Seems like it should be recordingId.
+    final convertRemindersToJsonPrompt =
+        '''You are a reminders assistant.  Convert the following list of reminder source data into JSON format, using fields "reminderId" "createTimestamp" "notifyTimestamp" "reminderDescription" "id".  There may be multiple reminders in the source data.  Create JSON for all reminders.
 
 Attributes common to each reminder: 
 
@@ -166,17 +168,17 @@ Example JSON using the desired formatting:
 Source Data:
 $reminderText''';
 
-_logger.i(convertRemindersToJsonPrompt);
+    _logger.i(convertRemindersToJsonPrompt);
 
     List<OpenAIChatCompletionChoiceMessageModel> messages = [
       OpenAIChatCompletionChoiceMessageModel(
-          role: OpenAIChatMessageRole.user, content: convertRemindersToJsonPrompt)
+          role: OpenAIChatMessageRole.user,
+          content: convertRemindersToJsonPrompt)
     ];
 
     final completion = await OpenAI.instance.chat
         .create(model: "gpt-3.5-turbo", messages: messages);
 
     return completion.choices[0].message.content;
-
-    }
+  }
 }

--- a/backend_services/lib/src/gpt-service/GptCalls.dart
+++ b/backend_services/lib/src/gpt-service/GptCalls.dart
@@ -139,7 +139,7 @@ Please ensure that every field in the list of fields has a value filled in, and 
   }
 
   Future<String> convertRemindersToJson(
-      String reminderText, String guid, DateTime createTimestamp) async {
+      String reminderText, String recordingId, DateTime createTimestamp) async {
     OpenAI.apiKey = _openAIApiKey;
 
     // JN: SM: Why is the 5th property id here and and guid in the object and userId in the file?  Seems like it should be recordingId.
@@ -149,7 +149,7 @@ Please ensure that every field in the list of fields has a value filled in, and 
 Attributes common to each reminder: 
 
 createTimestamp: $createTimestamp
-id: $guid
+recordingId: $recordingId
 
 "createTimestamp" represents the current time and will be the same for all.  "notifyTimestamp" is the time the reminder takes effect as noted in the source data.  Create a new unique UUID to populate "reminderId" field..
 
@@ -161,7 +161,7 @@ Example JSON using the desired formatting:
 		"createTimestamp": "2023-07-04T20:46:59.346827",
 		"notifyTimestamp": "2023-07-06T22:28:48.683649",
 		"reminderDescription": "Take out the trash",
-		"id": "6dd25210-276e-11ee-a831-510c56deaff3"
+		"recordingId": "6dd25210-276e-11ee-a831-510c56deaff3"
 	}
 ]
 

--- a/backend_services/lib/src/gpt-service/GptCalls.dart
+++ b/backend_services/lib/src/gpt-service/GptCalls.dart
@@ -142,9 +142,8 @@ Please ensure that every field in the list of fields has a value filled in, and 
       String reminderText, String recordingId, DateTime createTimestamp) async {
     OpenAI.apiKey = _openAIApiKey;
 
-    // JN: SM: Why is the 5th property id here and and guid in the object and userId in the file?  Seems like it should be recordingId.
     final convertRemindersToJsonPrompt =
-        '''You are a reminders assistant.  Convert the following list of reminder source data into JSON format, using fields "reminderId" "createTimestamp" "notifyTimestamp" "reminderDescription" "id".  There may be multiple reminders in the source data.  Create JSON for all reminders.  The response must only consist of complete properly-formatted JSON.
+        '''You are a reminders assistant.  Convert the following list of reminder source data into JSON format, using fields "reminderId" "createTimestamp" "notifyTimestamp" "reminderDescription" "recordingId".  There may be multiple reminders in the source data.  Create JSON for all reminders.  The response must only consist of complete properly-formatted JSON.
 
 Attributes common to each reminder: 
 

--- a/backend_services/lib/src/test-data/test_conversations.dart
+++ b/backend_services/lib/src/test-data/test_conversations.dart
@@ -77,10 +77,10 @@ spk_1: Remind me every day at 04:30 p.m. that dinner is in the cafeteria at 05:0
         duration: Duration(minutes: 3),
         recordedDate: DateTime.now().add(-Duration(hours: 3)),
         title: 'Description D',
-        transcript: '',
+        transcript: '''Remind me to prepare for a meeting on Thursdays at 9 a.m. The meeting will start at 10 a.m. This is on cloud meeting.''',
         customDescription: 'Description',
         gptDescription: '',
-        gptReminders: '',
+        gptReminders: '''Reminder 1: 2023-07-13T08:00, Prepare for Thursday's meeting at 9 a.m.\nReminder 2: 2023-07-13T10:00, Start the cloud meeting''',
         gptFoodOrder: '');
     Conversation recording5 = Conversation(
         id: 'e7cb2be9-75f2-44a0-9976-df7dfc0e1363',

--- a/backend_test_utility/integration_test/gpt_code_test.dart
+++ b/backend_test_utility/integration_test/gpt_code_test.dart
@@ -123,6 +123,18 @@ void main() async {
     logger.i(result);
   });
 
+    test('Send reminder text to OpenAI for conversion to JSON', () async {
+    final conversation = TestConversations.sampleConversations.firstWhereOrNull(
+        (convo) => convo.id == '866731c8-a9cd-408c-ae04-886f31a42493');
+    final gpt = GptCalls(EnvironmentVars.openAIApiKey);
+    expect(conversation, isNotNull);
+    expect(conversation!.gptReminders, isNotEmpty);
+
+    String? result = await gpt.convertRemindersToJson(
+        conversation.gptReminders, conversation.id, conversation.recordedDate);
+    logger.i(result);
+  });
+
 
 
 }

--- a/backend_test_utility/integration_test/reminder_code_test.dart
+++ b/backend_test_utility/integration_test/reminder_code_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:backend_services/agent.dart';
-import 'package:backend_services/model/reminder.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:logger/logger.dart';

--- a/backend_test_utility/integration_test/reminder_code_test.dart
+++ b/backend_test_utility/integration_test/reminder_code_test.dart
@@ -13,13 +13,29 @@ void main() async {
 
   final logger = Logger();
 
+    test('read existing reminder JSON files and return list of files', () async {
+    var agent = Agent('Reminder-API-Unit-test', directory);
+    expect(() => agent.conversationsProvider.reminders, returnsNormally);
+
+    agent.conversationsProvider.removeAllReminders();
+    expect(agent.conversationsProvider.reminders.length, 0);
+    agent.loadSampleReminderData();
+    //logger.i(
+    //    "test reminders count: ${agent.conversationsProvider.reminders.length}");
+    expect(agent.conversationsProvider.reminders.length, isNot(0));
+
+    var result = agent.conversationsProvider.reminders.toString();
+    expect(result, isNotNull);
+    logger.i(result);
+  });
+
 //todo Requirement 12 get reminders
 
 //todo add reminder
 
 //todo delete reminder
 
-  test('write reminders to reminders.json', () {
+/*  test('write reminders to reminders.json', () {
     var agent = Agent('browser-extension-api-unit-test', directory);
     agent.loadSampleReminderData;
     expect(() => agent.writeRemindersToFile(), returnsNormally);
@@ -62,4 +78,5 @@ void main() async {
       print(rem.toJson());
     }
   });
+  */
 }


### PR DESCRIPTION
* Change reminderId to UUID (int to String)
* use conversation ID as Reminder foreign key instead of UserId
* Move Reminder FileIO to conversationProvider, call Reminder add/remove methods similar to Conversation approach
* Create additional OpenAI method to convert Reminder string output into JSON List of Reminder objects
* Parse the JSON into Reminder List, add to reminders that are stored in file
* Modify backend_test_utility integration test for new approach

Reminders are not scoped to be consumed by UI but can be stored and maintained by backend services for future use.